### PR TITLE
fix SimulationCallback.OnContact crash (caused by a double free)

### DIFF
--- a/PhysX.Net-3.3/PhysX.Net-3/Source/ContactPair.cpp
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/ContactPair.cpp
@@ -25,8 +25,6 @@ ContactPair::~ContactPair()
 }
 ContactPair::!ContactPair()
 {
-	SAFE_DELETE(_pair);
-
 	this->Shape0 = nullptr;
 	this->Shape1 = nullptr;
 	this->ContactData = nullptr;


### PR DESCRIPTION
I believe there is a double free here that causes a crash.

The delete in ContactPair destructor causes a crash.
(i believe the SDK will also try to free it after finish calling OnContact callback?)
