### PR TITLE
Physics in now the joint owner/creator, not scene

### DIFF
--- a/PhysX.Net-3.3/PhysX.Net-3/Source/D6Joint.cpp
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/D6Joint.cpp
@@ -7,7 +7,7 @@
 #include "JointAngularLimitPair.h"
 //#include <PxD6Joint.h>
 
-D6Joint::D6Joint(PxD6Joint* joint, PhysX::Scene^ owner)
+D6Joint::D6Joint(PxD6Joint* joint, PhysX::Physics^ owner)
 	: Joint(joint, owner)
 {
 	

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/D6Joint.h
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/D6Joint.h
@@ -16,7 +16,7 @@ namespace PhysX
 	public ref class D6Joint : Joint
 	{
 	internal:
-		D6Joint(PxD6Joint* joint, PhysX::Scene^ owner);
+		D6Joint(PxD6Joint* joint, PhysX::Physics^ owner);
 
 	public:
 		/// <summary>

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/DistanceJoint.cpp
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/DistanceJoint.cpp
@@ -2,7 +2,7 @@
 //#include <PxDistanceJoint.h> 
 #include "DistanceJoint.h"
 
-DistanceJoint::DistanceJoint(PxDistanceJoint* joint, PhysX::Scene^ owner)
+DistanceJoint::DistanceJoint(PxDistanceJoint* joint, PhysX::Physics^ owner)
 	: Joint(joint, owner)
 {
 	

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/DistanceJoint.h
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/DistanceJoint.h
@@ -11,7 +11,7 @@ namespace PhysX
 	public ref class DistanceJoint : Joint
 	{
 		internal:
-			DistanceJoint(PxDistanceJoint* joint, PhysX::Scene^ owner);
+			DistanceJoint(PxDistanceJoint* joint, PhysX::Physics^ owner);
 
 		public:
 			

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/FixedJoint.cpp
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/FixedJoint.cpp
@@ -2,7 +2,7 @@
 //#include <PxFixedJoint.h> 
 #include "FixedJoint.h"
 
-FixedJoint::FixedJoint(PxFixedJoint* joint, PhysX::Scene^ owner)
+FixedJoint::FixedJoint(PxFixedJoint* joint, PhysX::Physics^ owner)
 	: Joint(joint, owner)
 {
 	

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/FixedJoint.h
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/FixedJoint.h
@@ -11,7 +11,7 @@ namespace PhysX
 	public ref class FixedJoint : Joint
 	{
 		internal:
-			FixedJoint(PxFixedJoint* joint, PhysX::Scene^ owner);
+			FixedJoint(PxFixedJoint* joint, PhysX::Physics^ owner);
 
 		public:
 			/// <summary>

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/Joint.cpp
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/Joint.cpp
@@ -8,19 +8,19 @@
 //#include <PxJoint.h>
 //#include <PxRigidActor.h>
 
-Joint::Joint(PxJoint* joint, PhysX::Scene^ owner)
+Joint::Joint(PxJoint* joint, PhysX::Physics^ owner)
 {
 	if (joint == NULL)
 		throw gcnew ArgumentNullException("joint");
-	ThrowIfNullOrDisposed(owner, "owner");
+	ThrowIfNull(owner, "owner");
 
 	_joint = joint;
-	_scene = owner;
+	_owner = owner;
 
 	// Constraint
 	_constraint = gcnew PhysX::Constraint(_joint->getConstraint(), this, false);
 
-	ObjectTable::Add((intptr_t)joint, this, owner);
+	ObjectTable::Add((intptr_t)joint, this, (PhysX::IDisposable^)owner);
 }
 Joint::~Joint()
 {
@@ -36,7 +36,7 @@ Joint::!Joint()
 	_joint->release();
 	_joint = NULL;
 
-	_scene = nullptr;
+	_owner = nullptr;
 	_constraint = nullptr;
 
 	OnDisposed(this, nullptr);
@@ -60,11 +60,6 @@ PhysX::Constraint^ Joint::Constraint::get()
 JointType Joint::Type::get()
 {
 	return ToManagedEnum(JointType, _joint->getType());
-}
-
-PhysX::Scene^ Joint::Scene::get()
-{
-	return _scene;
 }
 
 PhysX::Actor^ Joint::Actor0::get()

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/Joint.h
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/Joint.h
@@ -5,7 +5,7 @@
 
 namespace PhysX
 {
-	ref class Scene;
+	ref class Physics;
 	ref class Actor;
 	ref class Constraint;
 	ref class Serializable;
@@ -18,11 +18,11 @@ namespace PhysX
 
 		private:
 			PxJoint* _joint;
-			PhysX::Scene^ _scene;
+			PhysX::Physics^ _owner;
 			PhysX::Constraint^ _constraint;
 
 		internal:
-			Joint(PxJoint* joint, PhysX::Scene^ owner);
+			Joint(PxJoint* joint, PhysX::Physics^ owner);
 		public:
 			~Joint();
 		protected:
@@ -56,14 +56,6 @@ namespace PhysX
 			property JointType Type
 			{
 				JointType get();
-			}
-
-			/// <summary>
-			/// Gets the scene which this joint belongs to. 
-			/// </summary>
-			property PhysX::Scene^ Scene
-			{
-				PhysX::Scene^ get();
 			}
 
 			/// <summary>

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/Physics.h
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/Physics.h
@@ -5,6 +5,7 @@
 //#include <PxPhysics.h>
 //#include <PxDistanceJoint.h>
 //#include <PxRigidDynamic.h>
+#include "JointEnum.h"
 
 namespace PhysX
 {
@@ -40,7 +41,9 @@ namespace PhysX
 	ref class ClothFabricDesc;
 	ref class Articulation;
 	ref class Aggregate;
-	
+	ref class Joint;
+
+
 	namespace VisualDebugger
 	{
 		ref class Connection;
@@ -192,6 +195,32 @@ namespace PhysX
 		{
 			IEnumerable<RigidActor^>^ get();
 		}
+		#pragma endregion
+
+		#pragma region Joints
+		/// <summary>
+		/// Creates a joint.
+		/// </summary>
+		/// <param name="type">The type of the joint.</param>
+		/// <param name="actor0">An actor to which the joint is attached. Null may be used to attach the joint to a specific point in the world frame.</param>
+		/// <param name="">The position and orientation of the joint relative to actor0.</param>
+		/// <param name="actor1">An actor to which the joint is attached. Null may be used to attach the joint to a specific point in the world frame.</param>
+		/// <param name="">The position and orientation of the joint relative to actor1.</param>
+		/// <returns>A joint of the specified type.</returns>
+		Joint^ CreateJoint(JointType type, RigidActor^ actor0, Matrix localFrame0, RigidActor^ actor1, Matrix localFrame1);
+
+		/// <summary>
+		/// Creates a joint.
+		/// </summary>
+		/// <param name="type">The type of the joint.</param>
+		/// <param name="actor0">An actor to which the joint is attached. Null may be used to attach the joint to a specific point in the world frame.</param>
+		/// <param name="">The position and orientation of the joint relative to actor0.</param>
+		/// <param name="actor1">An actor to which the joint is attached. Null may be used to attach the joint to a specific point in the world frame.</param>
+		/// <param name="">The position and orientation of the joint relative to actor1.</param>
+		/// <returns>A joint of the specified type.</returns>
+		generic<typename T> where T : Joint
+			T CreateJoint(RigidActor^ actor0, Matrix localFrame0, RigidActor^ actor1, Matrix localFrame1);
+
 		#pragma endregion
 
 		#pragma region Particle System

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/PrismaticJoint.cpp
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/PrismaticJoint.cpp
@@ -3,7 +3,7 @@
 #include "JointLinearLimitPair.h"
 //#include <PxPrismaticJoint.h> 
 
-PrismaticJoint::PrismaticJoint(PxPrismaticJoint* joint, PhysX::Scene^ owner)
+PrismaticJoint::PrismaticJoint(PxPrismaticJoint* joint, PhysX::Physics^ owner)
 	: Joint(joint, owner)
 {
 	

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/PrismaticJoint.h
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/PrismaticJoint.h
@@ -13,7 +13,7 @@ namespace PhysX
 	public ref class PrismaticJoint : Joint
 	{
 		internal:
-			PrismaticJoint(PxPrismaticJoint* joint, PhysX::Scene^ owner);
+			PrismaticJoint(PxPrismaticJoint* joint, PhysX::Physics^ owner);
 
 		public:
 			/// <summary>

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/RevoluteJoint.cpp
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/RevoluteJoint.cpp
@@ -3,7 +3,7 @@
 #include "JointAngularLimitPair.h"
 //#include <PxRevoluteJoint.h> 
 
-RevoluteJoint::RevoluteJoint(PxRevoluteJoint* joint, PhysX::Scene^ owner)
+RevoluteJoint::RevoluteJoint(PxRevoluteJoint* joint, PhysX::Physics^ owner)
 	: Joint(joint, owner)
 {
 	

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/RevoluteJoint.h
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/RevoluteJoint.h
@@ -13,7 +13,7 @@ namespace PhysX
 	public ref class RevoluteJoint : Joint
 	{
 		internal:
-			RevoluteJoint(PxRevoluteJoint* joint, PhysX::Scene^ owner);
+			RevoluteJoint(PxRevoluteJoint* joint, PhysX::Physics^ owner);
 
 		public:
 			/// <summary>

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/Scene.cpp
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/Scene.cpp
@@ -11,14 +11,7 @@
 #include "ControllerManager.h"
 #include "Shape.h"
 #include "RaycastHit.h"
-#include "Joint.h"
-#include "D6Joint.h"
-#include "DistanceJoint.h"
-#include "FixedJoint.h"
 #include "RigidActor.h"
-#include "PrismaticJoint.h"
-#include "RevoluteJoint.h"
-#include "SphericalJoint.h"
 #include "SimulationStatistics.h"
 #include "Articulation.h"
 #include "Aggregate.h"
@@ -157,106 +150,13 @@ IEnumerable<Articulation^>^ Scene::Articulations::get()
 #pragma region Joints
 Joint^ Scene::CreateJoint(JointType type, RigidActor^ actor0, Matrix localFrame0, RigidActor^ actor1, Matrix localFrame1)
 {
-	PxPhysics* physics = this->Physics->UnmanagedPointer;
-
-	PxRigidActor* a0 = GetPointerOrNull(actor0);
-	PxRigidActor* a1 = GetPointerOrNull(actor1);
-
-	PxTransform lf0 = MathUtil::MatrixToPxTransform(localFrame0);
-	PxTransform lf1 = MathUtil::MatrixToPxTransform(localFrame1);
-
-	Joint^ joint = nullptr;
-
-	switch (type)
-	{
-		case JointType::D6:
-		{
-			auto d6 = PxD6JointCreate(*physics, a0, lf0, a1, lf1);
-
-			auto d6Joint = joint = gcnew D6Joint(d6, this);
-		}
-		break;
-
-		case JointType::Distance:
-		{
-			auto distance = PxDistanceJointCreate(*physics, a0, lf0, a1, lf1);
-
-			auto distanceJoint = joint = gcnew DistanceJoint(distance, this);
-		}
-		break;
-
-		case JointType::Fixed:
-		{
-			auto fixed = PxFixedJointCreate(*physics, a0, lf0, a1, lf1);
-
-			auto fixedJoint = joint = gcnew FixedJoint(fixed, this);
-		}
-		break;
-
-		case JointType::Prismatic:
-		{
-			auto primatic = PxPrismaticJointCreate(*physics, a0, lf0, a1, lf1);
-
-			auto primaticJoint = joint = gcnew PrismaticJoint(primatic, this);
-		}
-		break;
-
-		case JointType::Revolute:
-		{
-			auto revolute = PxRevoluteJointCreate(*physics, a0, lf0, a1, lf1);
-
-			auto revoluteJoint = joint = gcnew RevoluteJoint(revolute, this);
-		}
-		break;
-
-		case JointType::Spherical:
-		{
-			auto spherical = PxSphericalJointCreate(*physics, a0, lf0, a1, lf1);
-
-			auto sphericalJoint = joint = gcnew SphericalJoint(spherical, this);
-		}
-		break;
-	}
-
-	if (joint == nullptr)
-		throw gcnew ArgumentException(String::Format("Unsupported joint type {0}", type));
-
-	return joint;
+	return this->Physics->CreateJoint(type, actor0, localFrame0, actor1, localFrame1);
 }
 
 generic<typename T> where T : Joint
 T Scene::CreateJoint(RigidActor^ actor0, Matrix localFrame0, RigidActor^ actor1, Matrix localFrame1)
 {
-	JointType type;
-
-	if (T::typeid == D6Joint::typeid)
-		type = JointType::D6;
-
-	else if (T::typeid == DistanceJoint::typeid)
-		type = JointType::Distance;
-
-	else if (T::typeid == FixedJoint::typeid)
-		type = JointType::Fixed;
-
-	else if (T::typeid == PrismaticJoint::typeid)
-		type = JointType::Prismatic;
-
-	else if (T::typeid == RevoluteJoint::typeid)
-		type = JointType::Revolute;
-
-	else if (T::typeid == SphericalJoint::typeid)
-		type = JointType::Spherical;
-
-	else
-		throw gcnew ArgumentException("Unsupported joint type");
-
-	return (T)CreateJoint(type, actor0, localFrame0, actor1, localFrame1);
-}
-
-IEnumerable<Joint^>^ Scene::Joints::get()
-{
-	// Extend this object table method to support inheritance selection
-	return ObjectTable::GetObjectsOfOwnerAndType<Joint^>(this);
+	return this->Physics->CreateJoint<T>(actor0, localFrame0, actor1, localFrame1);
 }
 #pragma endregion
 

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/Scene.h
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/Scene.h
@@ -168,14 +168,6 @@ namespace PhysX
 			/// <returns>A joint of the specified type.</returns>
 			generic<typename T> where T : Joint
 			T CreateJoint(RigidActor^ actor0, Matrix localFrame0, RigidActor^ actor1, Matrix localFrame1);
-
-			/// <summary>
-			/// Gets the joints in the scene.
-			/// </summary>
-			property IEnumerable<Joint^>^ Joints
-			{
-				IEnumerable<Joint^>^ get();
-			}
 			#pragma endregion
 
 			#pragma region Grouping

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/SphericalJoint.cpp
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/SphericalJoint.cpp
@@ -3,7 +3,7 @@
 #include "JointLimitCone.h"
 //#include <PxSphericalJoint.h> 
 
-SphericalJoint::SphericalJoint(PxSphericalJoint* joint, PhysX::Scene^ owner)
+SphericalJoint::SphericalJoint(PxSphericalJoint* joint, PhysX::Physics^ owner)
 	: Joint(joint, owner)
 {
 

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/SphericalJoint.h
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/SphericalJoint.h
@@ -13,7 +13,7 @@ namespace PhysX
 	public ref class SphericalJoint : Joint
 	{
 		internal:
-			SphericalJoint(PxSphericalJoint* joint, PhysX::Scene^ owner);
+			SphericalJoint(PxSphericalJoint* joint, PhysX::Physics^ owner);
 
 		public:
 			/// <summary>


### PR DESCRIPTION
Changed owner to the physics object instead of scene to match the PhysX sdk architecture and for user to be able to create joints without the scene.
I left the CreateJoint() in scene class but they ask physic to make them.