### PR TITLE
Disposing a shape inside a trigger

### DIFF
--- a/PhysX.Net-3.3/PhysX.Net-3/Source/TriggerPair.cpp
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/TriggerPair.cpp
@@ -16,9 +16,11 @@ PxTriggerPair TriggerPair::ToUnmanaged(TriggerPair^ pair)
 TriggerPair^ TriggerPair::ToManaged(PxTriggerPair pair)
 {
 	auto tp = gcnew TriggerPair();
-		tp->OtherShape = ObjectTable::GetObject<Shape^>((intptr_t)pair.otherShape);
+		tp->OtherShape = ObjectTable::TryGetObject<Shape^>((intptr_t)pair.otherShape);
+		tp->OtherActor = ObjectTable::TryGetObject<RigidActor^>((intptr_t)pair.otherActor);
 		tp->Status = ToManagedEnum(PairFlag, pair.status);
-		tp->TriggerShape = ObjectTable::GetObject<Shape^>((intptr_t)pair.triggerShape);
+		tp->TriggerShape = ObjectTable::TryGetObject<Shape^>((intptr_t)pair.triggerShape);
+		tp->TriggerActor = ObjectTable::TryGetObject<RigidActor^>((intptr_t)pair.triggerActor);
 
 	return tp;
 }

--- a/PhysX.Net-3.3/PhysX.Net-3/Source/TriggerPair.h
+++ b/PhysX.Net-3.3/PhysX.Net-3/Source/TriggerPair.h
@@ -5,6 +5,7 @@
 namespace PhysX
 {
 	ref class Shape;
+	ref class RigidActor;
 
 	public ref class TriggerPair
 	{
@@ -19,9 +20,19 @@ namespace PhysX
 			property Shape^ TriggerShape;
 
 			/// <summary>
+			/// Gets or sets the actor that has been marked as a trigger.
+			/// </summary>
+			property RigidActor^ TriggerActor;
+
+			/// <summary>
 			/// Gets or sets the shape causing the trigger event.
 			/// </summary>
 			property Shape^ OtherShape;
+
+			/// <summary>
+			/// Gets or sets the actor causing the trigger event.
+			/// </summary>
+			property RigidActor^ OtherActor;
 
 			/// <summary>
 			/// Gets or sets the type of trigger event (eNOTIFY_TOUCH_FOUND, eNOTIFY_TOUCH_PERSISTS or eNOTIFY_TOUCH_LOST).


### PR DESCRIPTION
PhysX generates a TriggerEvent when a shape is disposed inside a trigger. But the ObjectTable doesnt know the disposed shape so an exception is thrown. Changed GetObject to TryGetObject -> now the OtherShape is just null which isnt perfect but at least if wont fail... Also added OtherActor and TriggerActor to TriggerPair.